### PR TITLE
Fix greenhouse postings no query

### DIFF
--- a/Controllers/ApiController.cs
+++ b/Controllers/ApiController.cs
@@ -52,6 +52,11 @@ namespace Etch.OrchardCore.Greenhouse.Controllers
 
             var luceneQuery = (await _queryManager.GetQueryAsync(parameters.Query)) as LuceneQuery;
 
+            if (luceneQuery == null)
+            {
+                return BadRequest();
+            }
+
             var queryParameters = new Dictionary<string, object>
             {
                 { "department", parameters.Department },

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "0.7.1",
+    Version = "0.7.2",
     Website = "https://etchuk.com"
 )]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etch.orchardcore.greenhouse",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Integrates Greenhouse with Orchard Core",
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
When fetching Greenhouse postings via the API controller, if the specified query doesn't exist then it will return a 400 response instead of a null reference exception.