### PR TITLE
Add ability to prefill filter options

### DIFF
--- a/Filters/DepartmentOptionsFilter.cs
+++ b/Filters/DepartmentOptionsFilter.cs
@@ -22,13 +22,14 @@ namespace Etch.OrchardCore.Greenhouse.Filters
         public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
             var departments = new List<string>();
+            var selectedItem = arguments.At(0).ToStringValue();
 
             foreach (var value in input.Enumerate(context))
             {
                 departments.Add((await value.GetValueAsync($"{nameof(GreenhousePostingPart)}.{nameof(GreenhousePostingPart.Department)}", context)).ToStringValue());
             }
 
-            return new StringValue(StringUtils.GetOptions(departments.Distinct().OrderBy(x => x).ToList(), _httpContextAccessor.HttpContext.Request.Query["department"].FirstOrDefault()));
+            return new StringValue(StringUtils.GetOptions(departments.Distinct().OrderBy(x => x).ToList(), selectedItem));
         }
     }
 }

--- a/Filters/LocationOptionsFilter.cs
+++ b/Filters/LocationOptionsFilter.cs
@@ -22,13 +22,14 @@ namespace Etch.OrchardCore.Greenhouse.Filters
         public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
             var locations = new List<string>();
+            var selectedItem = arguments.At(0).ToStringValue();
 
             foreach (var value in input.Enumerate(context))
             {
                 locations.Add((await value.GetValueAsync($"{nameof(GreenhousePostingPart)}.{nameof(GreenhousePostingPart.Location)}", context)).ToStringValue());
             }
 
-            return new StringValue(StringUtils.GetOptions(locations.Distinct().OrderBy(x => x).ToList(), _httpContextAccessor.HttpContext.Request.Query["location"].FirstOrDefault()));
+            return new StringValue(StringUtils.GetOptions(locations.Distinct().OrderBy(x => x).ToList(), selectedItem));
         }
     }
 }

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -67,5 +67,12 @@ namespace Etch.OrchardCore.Greenhouse
 
             return 6;
         }
+
+        public async Task<int> UpdateFrom6()
+        {
+            await _recipeMigrator.ExecuteAsync("update6.recipe.json", this);
+
+            return 7;
+        }
     }
 }

--- a/Migrations/update6.recipe.json
+++ b/Migrations/update6.recipe.json
@@ -1,0 +1,59 @@
+{
+    "name": "",
+    "issetuprecipe": false,
+    "steps": [
+        {
+            "name": "ContentDefinition",
+            "ContentParts": [
+                {
+                    "Name": "GreenhousePostings",
+                    "Settings": {},
+                    "ContentPartFieldDefinitionRecords": [
+                        {
+                            "FieldName": "TextField",
+                            "Name": "DepartmentPrefill",
+                            "Settings": {
+                                "ContentPartFieldSettings": {
+                                    "DisplayName": "Prefill Department Filter",
+                                    "Position": "13"
+                                },
+                                "TextFieldSettings": {
+                                    "Hint": "Optionally specify a department to display by default. If not specified, all departments will be displayed."
+                                },
+                                "ContentIndexSettings": {}
+                            }
+                        },
+                        {
+                            "FieldName": "TextField",
+                            "Name": "LocationPrefill",
+                            "Settings": {
+                                "ContentPartFieldSettings": {
+                                    "DisplayName": "Prefill Location Filter",
+                                    "Position": "14"
+                                },
+                                "TextFieldSettings": {
+                                    "Hint": "Optionally specify a location to display by default. If not specified, all locations will be displayed."
+                                },
+                                "ContentIndexSettings": {}
+                            }
+                        },
+                        {
+                            "FieldName": "BooleanField",
+                            "Name": "HideDepartmentFilter",
+                            "Settings": {
+                                "ContentPartFieldSettings": {
+                                    "DisplayName": "Hide Department Filter",
+                                    "Position": "10"
+                                },
+                                "BooleanFieldSettings": {
+                                    "Hint": "You may wish to hide the department filter by ticking this box."
+                                },
+                                "ContentIndexSettings": {}
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Views/Widget-GreenhousePostings.liquid
+++ b/Views/Widget-GreenhousePostings.liquid
@@ -16,13 +16,21 @@
 
 {% assign allPostings = Queries.AllGreenhousePostings | query %}
 
-{% assign location = Request.Query.location | first %}
-{% assign department = Request.Query.department | first %}
+{% assign location = greenhousePostings.LocationPrefill.Text %}
+{% assign department = greenhousePostings.DepartmentPrefill.Text %}
+
+{% if Request.Query.location != nil %}
+    {% assign location = Request.Query.location | first %}
+{% endif %}
+
+{% if Request.Query.department != nil %}
+    {% assign department = Request.Query.department | first %}
+{% endif %}
 
 {% assign page = Request.Query["page"] | first | at_least: 1 %}
 {% assign fromValue = page | times: pageSize | minus: pageSize  | at_least: 0 %}
 
-{% assign showPinned = location == nil and department == nil and page == 1 %}
+{% assign showPinned = location == blank and department == blank and page == 1 %}
 
 {% if showPinned %}
     {% assign pageSize = pageSize | minus: pinnedPostings.size  %}
@@ -89,7 +97,7 @@
             </label>
 
             <select id="location" name="location" class="js-filterable-jobs-filter">
-                {{ allPostings | greenhouse_location_options | raw }}
+                {{ allPostings | greenhouse_location_options: location | raw }}
             </select>
         </div>
         {% endif %}
@@ -104,7 +112,7 @@
                     {% endif %}
                 </label>
                 <select id="department" name="department" class="js-filterable-jobs-filter">
-                    {{ allPostings | greenhouse_department_options | raw }}
+                    {{ allPostings | greenhouse_department_options: department | raw }}
                 </select>
             </div>
         {% endif %}

--- a/placement.json
+++ b/placement.json
@@ -1,71 +1,63 @@
 {
-  "BooleanField_Edit": [
-    {
-      "place": "Parts#Paging:1",
-      "differentiator": "GreenhousePostings-Paging",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Filter:10",
-      "differentiator": "GreenhousePostings-HideDepartmentFilter",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Filter:12",
-      "differentiator": "GreenhousePostings-HideLocationFilter",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    }
-  ],
-  "NumericField_Edit": [
-    {
-      "place": "Parts#Paging:2",
-      "differentiator": "GreenhousePostings-PageSize",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    }
-  ],
-  "TextField_Edit": [
-    {
-      "place": "Parts#Filter:11",
-      "differentiator": "GreenhousePostings-DepartmentLabel",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Filter:13",
-      "differentiator": "GreenhousePostings-LocationLabel",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Paging:4",
-      "differentiator": "GreenhousePostings-NextPageLabel",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Paging:5",
-      "differentiator": "GreenhousePostings-PreviousPageLabel",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    },
-    {
-      "place": "Parts#Filter:20",
-      "differentiator": "GreenhousePostings-SubmitLabel",
-      "contentType": [
-        "GreenhousePostings"
-      ]
-    }
-  ]
+    "BooleanField_Edit": [
+        {
+            "place": "Parts#Paging:1",
+            "differentiator": "GreenhousePostings-Paging",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:10",
+            "differentiator": "GreenhousePostings-HideDepartmentFilter",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:13",
+            "differentiator": "GreenhousePostings-HideLocationFilter",
+            "contentType": ["GreenhousePostings"]
+        }
+    ],
+    "NumericField_Edit": [
+        {
+            "place": "Parts#Paging:2",
+            "differentiator": "GreenhousePostings-PageSize",
+            "contentType": ["GreenhousePostings"]
+        }
+    ],
+    "TextField_Edit": [
+        {
+            "place": "Parts#Filter:11",
+            "differentiator": "GreenhousePostings-DepartmentLabel",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:12",
+            "differentiator": "GreenhousePostings-DepartmentPrefill",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:14",
+            "differentiator": "GreenhousePostings-LocationLabel",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:15",
+            "differentiator": "GreenhousePostings-LocationPrefill",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Paging:4",
+            "differentiator": "GreenhousePostings-NextPageLabel",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Paging:5",
+            "differentiator": "GreenhousePostings-PreviousPageLabel",
+            "contentType": ["GreenhousePostings"]
+        },
+        {
+            "place": "Parts#Filter:20",
+            "differentiator": "GreenhousePostings-SubmitLabel",
+            "contentType": ["GreenhousePostings"]
+        }
+    ]
 }


### PR DESCRIPTION
Includes migration to add the new fields, a typo fix to hint text of adjacent field, relevant placement json adjustments, widget functionality amends, ability to be overridden by query if desired, and adjusting liquid filter to set selected item appropriately.

Before merge, I think we should review whether we can remove any dependencies from the Filter.cs files - as they no longer use the httpContextAccessor, we may be able to remove some additional lines but I wasn't sure so I didn't want to hack them out without your guidance :)