### PR TITLE
Add ability to use invisible recaptcha on application form

### DIFF
--- a/Drivers/GreenhousePostingFormPartDisplayDriver.cs
+++ b/Drivers/GreenhousePostingFormPartDisplayDriver.cs
@@ -8,6 +8,9 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Entities;
+using OrchardCore.ReCaptcha.Configuration;
+using OrchardCore.Settings;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -19,14 +22,19 @@ namespace Etch.OrchardCore.Greenhouse.Drivers
         #region Dependencies
 
         private readonly IGreenhouseQuestionShapeFactory _greenhouseQuestionShapeFactory;
+        private readonly ISiteService _siteService;
 
         #endregion
 
         #region Constructor
 
-        public GreenhousePostingFormPartDisplayDriver(IGreenhouseQuestionShapeFactory greenhouseQuestionShapeFactory)
+        public GreenhousePostingFormPartDisplayDriver(
+            IGreenhouseQuestionShapeFactory greenhouseQuestionShapeFactory,
+            ISiteService siteService
+            )
         {
             _greenhouseQuestionShapeFactory = greenhouseQuestionShapeFactory;
+            _siteService = siteService;
         }
 
         #endregion
@@ -39,6 +47,9 @@ namespace Etch.OrchardCore.Greenhouse.Drivers
             {
                 return null;
             }
+
+            var siteSettings = await _siteService.GetSiteSettingsAsync();
+            var recaptchaSettings = siteSettings.As<ReCaptchaSettings>();
 
             var settings = context.TypePartDefinition.GetSettings<GreenhousePostingFormPartSettings>();
             var postingPart = part.ContentItem.As<GreenhousePostingPart>();
@@ -62,8 +73,10 @@ namespace Etch.OrchardCore.Greenhouse.Drivers
                 model.Questions = questions;
                 model.Posting = posting;
                 model.PostingPart = postingPart;
+                model.ReCaptchaSettings = recaptchaSettings;
                 model.Settings = settings;
                 model.ShowApplicationForm = settings.ShowApplicationForm && part.ShowApplicationForm;
+                model.UseReCaptcha = settings.UseReCaptcha && recaptchaSettings != null && recaptchaSettings.IsValid();
             }).Location("Detail", "Content:10");
         }
 

--- a/Drivers/GreenhousePostingFormPartSettingsDisplayDriver.cs
+++ b/Drivers/GreenhousePostingFormPartSettingsDisplayDriver.cs
@@ -2,21 +2,33 @@
 using Etch.OrchardCore.Greenhouse.ViewModels;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Environment.Shell;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Greenhouse.Drivers
 {
     public class GreenhousePostingFormPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
-        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        private readonly IShellFeaturesManager _shellFeaturesManager;
+
+        public GreenhousePostingFormPartSettingsDisplayDriver(IShellFeaturesManager shellFeaturesManager)
+        {
+            _shellFeaturesManager = shellFeaturesManager;
+        }
+
+        public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
             if (!string.Equals(nameof(GreenhousePostingFormPart), contentTypePartDefinition.PartDefinition.Name))
             {
                 return null;
             }
+
+            var enabledFeatures = await _shellFeaturesManager.GetEnabledExtensionsAsync();
 
             return Initialize<GreenhousePostingFormPartSettingsViewModel>("GreenhousePostingFormPartSettings_Edit", model =>
             {
@@ -25,9 +37,11 @@ namespace Etch.OrchardCore.Greenhouse.Drivers
                 model.AllowedFileExtensions = string.Join(",", settings.AllowedFileExtensions ?? Array.Empty<string>());
                 model.ApplicationErrorMessage = settings.ApplicationErrorMessage;
                 model.ApplicationSuccessUrl = settings.ApplicationSuccessUrl;
+                model.HasReCaptchaEnabled = enabledFeatures.Any(x => x.Id == "OrchardCore.ReCaptcha");
                 model.MaxFileSize = settings.MaxFileSize;
                 model.ShowApplicationForm = settings.ShowApplicationForm;
                 model.SubmitButtonLabel = settings.SubmitButtonLabel;
+                model.UseReCaptcha = settings.UseReCaptcha;
                 model.ValidationErrorsMessage = settings.ValidationErrorsMessage;
             }).Location("Content");
         }
@@ -51,10 +65,11 @@ namespace Etch.OrchardCore.Greenhouse.Drivers
                 MaxFileSize = model.MaxFileSize,
                 ShowApplicationForm = model.ShowApplicationForm,
                 SubmitButtonLabel = model.SubmitButtonLabel,
+                UseReCaptcha = model.UseReCaptcha,
                 ValidationErrorsMessage = model.ValidationErrorsMessage
             });
 
-            return Edit(contentTypePartDefinition, context.Updater);
+            return await EditAsync(contentTypePartDefinition, context.Updater);
         }
     }
 }

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="OrchardCore.Infrastructure" Version="1.3.0" />
     <PackageReference Include="OrchardCore.Lucene" Version="1.3.0" />
     <PackageReference Include="OrchardCore.Navigation.Core" Version="1.3.0" />
+    <PackageReference Include="OrchardCore.ReCaptcha" Version="1.3.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="1.3.0" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.3.0" />
     <PackageReference Include="OrchardCore.Title" Version="1.3.0" />

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "1.0.0",
+    Version = "1.1.0",
     Website = "https://etchuk.com"
 )]
 

--- a/ModelBinding/AttachmentModelBinder.cs
+++ b/ModelBinding/AttachmentModelBinder.cs
@@ -36,7 +36,7 @@ namespace Etch.OrchardCore.Greenhouse.ModelBinding
             var fileField = question.Fields.FirstOrDefault(x => x.Type == Constants.GreenhouseFieldTypes.Attachment);
             var textField = question.Fields.FirstOrDefault(x => x.Type == Constants.GreenhouseFieldTypes.LongText);
 
-            if (question.Required.HasValue && question.Required.Value && !request.Form.Files.Any(x => x.Name == fileField.Name) && string.IsNullOrWhiteSpace(request.Form[textField.Name]))
+            if (question.Required.HasValue && question.Required.Value && !request.Form.Files.Any(x => x.Name == fileField.Name) && (textField == null || string.IsNullOrWhiteSpace(request.Form[textField.Name])))
             {
                 modelState.AddModelError(fileField.Name, $"{question.Label} is required");
                 return null;

--- a/Models/GreenhousePostingFormPartSettings.cs
+++ b/Models/GreenhousePostingFormPartSettings.cs
@@ -8,6 +8,7 @@
         public long MaxFileSize { get; set; } = Constants.Defaults.MaxFileSize;
         public bool ShowApplicationForm { get; set; }
         public string SubmitButtonLabel { get; set; }
+        public bool UseReCaptcha { get; set; }
         public string ValidationErrorsMessage { get; set; }
     }
 }

--- a/ViewModels/GreenhousePostingFormPartSettingsViewModel.cs
+++ b/ViewModels/GreenhousePostingFormPartSettingsViewModel.cs
@@ -5,9 +5,12 @@
         public string AllowedFileExtensions { get; set; }
         public string ApplicationErrorMessage { get; set; }
         public string ApplicationSuccessUrl { get; set; }
+        public bool HasReCaptchaEnabled { get; set; }
         public long MaxFileSize { get; set; }
         public bool ShowApplicationForm { get; set; }
         public string SubmitButtonLabel { get; set; }
+        public bool UseReCaptcha { get; set; }
         public string ValidationErrorsMessage { get; set; }
+
     }
 }

--- a/ViewModels/GreenhousePostingFormPartViewModel.cs
+++ b/ViewModels/GreenhousePostingFormPartViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Etch.OrchardCore.Greenhouse.Models;
 using Etch.OrchardCore.Greenhouse.Services.Dtos;
 using OrchardCore.ContentManagement;
+using OrchardCore.ReCaptcha.Configuration;
 using System.Collections.Generic;
 
 namespace Etch.OrchardCore.Greenhouse.ViewModels
@@ -12,7 +13,9 @@ namespace Etch.OrchardCore.Greenhouse.ViewModels
         public GreenhouseJobPosting Posting { get; set; }
         public GreenhousePostingPart PostingPart { get; set; }
         public IList<dynamic> Questions { get; set; }
+        public ReCaptchaSettings ReCaptchaSettings { get; set; }
         public GreenhousePostingFormPartSettings Settings { get; set; }
         public bool ShowApplicationForm {get; set; }
+        public bool UseReCaptcha { get; set; }
     }
 }

--- a/Views/GreenhousePostingFormPart.cshtml
+++ b/Views/GreenhousePostingFormPart.cshtml
@@ -8,9 +8,31 @@
 
 @if (Model.ShowApplicationForm)
 {
+    @if (Model.UseReCaptcha)
+    {
+        <script at="Head">
+            window.onGreenhouseRecaptchComplete = function(token) {
+                document.getElementById('greenhouse-apply-form').submit();
+            }
+
+            window.onGreenhouseApplySubmit = function() {
+                grecaptcha.execute();
+                return false;
+            };
+        </script>
+
+        <script src="https://www.google.com/recaptcha/api.js" at="Head" async defer></script>
+    }
+
     <section id="@Constants.AnchorUrl" class="section section--spaced-after-none" style="--sectionBackgroundColor:#eae8e5;">
         <div class="section__content constrain">
-            <form method="post" action="@Context.Request.PathBase/greenhouse/apply/@Model.ContentItem.ContentItemId" enctype="multipart/form-data">
+            <form 
+                id="greenhouse-apply-form" 
+                method="post" 
+                action="@Context.Request.PathBase/greenhouse/apply/@Model.ContentItem.ContentItemId" 
+                enctype="multipart/form-data"
+                onsubmit="@(Model.UseReCaptcha ? "window.onGreenhouseApplySubmit()" : string.Empty)">
+
                 @if (TempData.ContainsKey(Constants.TempDataKeys.ApplicationError))
                 {
                     <p class="alert alert--error">@TempData[Constants.TempDataKeys.ApplicationError]</p>
@@ -28,7 +50,19 @@
 
                 @Html.AntiForgeryToken()
 
-                <button type="submit" class="btn btn--primary">@Model.Settings.SubmitButtonLabel</button>
+                @if (Model.UseReCaptcha)
+                {
+                    <div class="g-recaptcha"
+                      data-sitekey="@Model.ReCaptchaSettings.SiteKey"
+                      data-callback="onGreenhouseRecaptchComplete"
+                      data-size="invisible"></div>
+                }
+
+                <button 
+                    class="btn btn--primary g-recaptcha"
+                    type="submit"
+                    data-sitekey="6Le40u4gAAAAAKiNH5ejY2iGO7X1wYaf7B3WB03p" 
+                    data-callback="onWorkableApplySubmit">@Model.Settings.SubmitButtonLabel</button>
             </form>
         </div>
     </section>

--- a/Views/GreenhousePostingFormPartSettings.Edit.cshtml
+++ b/Views/GreenhousePostingFormPartSettings.Edit.cshtml
@@ -1,6 +1,5 @@
 ﻿@model Etch.OrchardCore.Greenhouse.ViewModels.GreenhousePostingFormPartSettingsViewModel
 
-
 <div class="form-group">
     <div class="custom-control custom-checkbox">
         <input asp-for="ShowApplicationForm" type="checkbox" class="custom-control-input content-preview-select" checked="@Model.ShowApplicationForm" />
@@ -50,3 +49,18 @@
     <input asp-for="MaxFileSize" class="form-control" />
     <span class="hint">@T["Maximum file size (in bytes) for files that are attached to job application."]</span>
 </div>
+
+@if (Model.HasReCaptchaEnabled) 
+{
+    <h4>Antispam</h4>
+
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input asp-for="UseReCaptcha" type="checkbox" class="custom-control-input content-preview-select" checked="@Model.UseReCaptcha" />
+            <label class="custom-control-label" asp-for="UseReCaptcha">
+                @T["Enable ReCaptcha"]
+                <span class="hint dashed">@T["Use ReCaptcha to prevent spam on application form."]</span>
+            </label>
+        </div>
+    </div>
+}


### PR DESCRIPTION
If the ReCaptcha feature is enabled and configured, ReCaptcha can be enabled within the Greenhouse form part settings.