### PR TITLE
Job import failing

### DIFF
--- a/Services/Dtos/GreenhouseAttachment.cs
+++ b/Services/Dtos/GreenhouseAttachment.cs
@@ -1,19 +1,19 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseAttachment
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public string Content { get; set; }
 
-        [JsonProperty("content_type")]
+        [JsonPropertyName("content_type")]
         public string ContentType { get; set; }
 
-        [JsonProperty("filename")]
+        [JsonPropertyName("filename")]
         public string Filename { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseDepartment.cs
+++ b/Services/Dtos/GreenhouseDepartment.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseDepartment
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseField.cs
+++ b/Services/Dtos/GreenhouseField.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseField
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
 
-        [JsonProperty("values")]
+        [JsonPropertyName("values")]
         public GreenhouseQuestionValue[] Values { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseJob.cs
+++ b/Services/Dtos/GreenhouseJob.cs
@@ -1,49 +1,48 @@
-using J2N.Collections.Generic;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseJob
     {
-        [JsonProperty("confidential")]
+        [JsonPropertyName("confidential")]
         public bool Confidential { get; set; }
 
-        [JsonProperty("closed_at")]
+        [JsonPropertyName("closed_at")]
         public DateTime? ClosedAt { get; set; }
 
-        [JsonProperty("created_at")]
+        [JsonPropertyName("created_at")]
         public DateTime CreatedAt { get; set; }
 
-        [JsonProperty("departments")]
+        [JsonPropertyName("departments")]
         public GreenhouseDepartment[] Departments { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("is_template")]
+        [JsonPropertyName("is_template")]
         public bool IsTemplate { get; set; }
 
-        [JsonProperty("metadata")]
+        [JsonPropertyName("metadata")]
         public IList<GreenhouseMetadata> Metadata { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("notes")]
+        [JsonPropertyName("notes")]
         public string Notes { get; set; }
 
-        [JsonProperty("offices")]
+        [JsonPropertyName("offices")]
         public GreenhouseOffice[] Offices { get; set; }
 
-        [JsonProperty("opened_at")]
+        [JsonPropertyName("opened_at")]
         public DateTime OpenedAt { get; set; }
 
-        [JsonProperty("statud")]
+        [JsonPropertyName("statud")]
         public string Status { get; set; }
 
-        [JsonProperty("updated_at")]
+        [JsonPropertyName("updated_at")]
         public DateTime UpdatedAt { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseJobBoard.cs
+++ b/Services/Dtos/GreenhouseJobBoard.cs
@@ -1,11 +1,11 @@
-﻿using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseJobBoard
     {
-        [JsonProperty("jobs")]
+        [JsonPropertyName("jobs")]
         public IList<GreenhouseJobBoardJob> Jobs { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseJobBoardJob.cs
+++ b/Services/Dtos/GreenhouseJobBoardJob.cs
@@ -1,27 +1,27 @@
-﻿using Newtonsoft.Json;
 using System;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseJobBoardJob
     {
-        [JsonProperty("absolute_url")]
+        [JsonPropertyName("absolute_url")]
         public string AbsoluteUrl { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("internal_job_id")]
+        [JsonPropertyName("internal_job_id")]
         public long InternalJobId { get; set; }
 
-        [JsonProperty("location")]
+        [JsonPropertyName("location")]
         public GreenhouseLocation Location { get; set; }
 
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
-        [JsonProperty("updated_at")]
+        [JsonPropertyName("updated_at")]
         public DateTime UpdatedAt { get; set; }
 
         public long PostingId

--- a/Services/Dtos/GreenhouseJobPosting.cs
+++ b/Services/Dtos/GreenhouseJobPosting.cs
@@ -1,57 +1,57 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseJobPosting
     {
-        [JsonProperty("active")]
+        [JsonPropertyName("active")]
         public bool Active { get; set; }
 
-        [JsonProperty("created_at")]
+        [JsonPropertyName("created_at")]
         public DateTime CreatedAt { get; set; }
 
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public string Content { get; set; }
 
-        [JsonProperty("departments")]
+        [JsonPropertyName("departments")]
         public GreenhouseDepartment[] Departments { get; set; }
 
-        [JsonProperty("external")]
+        [JsonPropertyName("external")]
         public bool External { get; set; }
 
-        [JsonProperty("first_published_at")]
+        [JsonPropertyName("first_published_at")]
         public DateTime? FirstPublishedAt { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("internal")]
+        [JsonPropertyName("internal")]
         public bool Internal { get; set; }
 
-        [JsonProperty("internal_content")]
+        [JsonPropertyName("internal_content")]
         public string InternalContent { get; set; }
 
-        [JsonProperty("job_id")]
+        [JsonPropertyName("job_id")]
         public long JobId { get; set; }
 
-        [JsonProperty("live")]
+        [JsonPropertyName("live")]
         public bool Live { get; set; }
 
-        [JsonProperty("location")]
+        [JsonPropertyName("location")]
         public GreenhouseLocation Location { get; set; }
 
-        [JsonProperty("metadata")]
+        [JsonPropertyName("metadata")]
         public IList<GreenhouseMetadata> Metadata { get; set; }
 
-        [JsonProperty("questions")]
+        [JsonPropertyName("questions")]
         public IList<GreenhouseQuestion> Questions { get; set; }
 
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
-        [JsonProperty("updated_at")]
+        [JsonPropertyName("updated_at")]
         public DateTime UpdatedAt { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseMetadata.cs
+++ b/Services/Dtos/GreenhouseMetadata.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseMetadata
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string[] Value { get; set; }
 
-        [JsonProperty("value_type")]
+        [JsonPropertyName("value_type")]
         public string ValueType { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseOffice.cs
+++ b/Services/Dtos/GreenhouseOffice.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseOffice
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public long Id { get; set; }
 
-        [JsonProperty("location")]
+        [JsonPropertyName("location")]
         public GreenhouseLocation Location { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseQuestion.cs
+++ b/Services/Dtos/GreenhouseQuestion.cs
@@ -1,19 +1,19 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseQuestion
     {
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
-        [JsonProperty("fields")]
+        [JsonPropertyName("fields")]
         public GreenhouseField[] Fields { get; set; }
 
-        [JsonProperty("label")]
+        [JsonPropertyName("label")]
         public string Label { get; set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool? Required { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseQuestionValue.cs
+++ b/Services/Dtos/GreenhouseQuestionValue.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseQuestionValue
     {
-        [JsonProperty("label")]
+        [JsonPropertyName("label")]
         public string Label { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public long Value { get; set; }
     }
 }

--- a/Services/Dtos/GreenhouseValueType.cs
+++ b/Services/Dtos/GreenhouseValueType.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
 {
     public class GreenhouseValueType
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string Value { get; set; }
     }
 }

--- a/Services/GreenhouseApiService.cs
+++ b/Services/GreenhouseApiService.cs
@@ -1,4 +1,4 @@
-﻿using Etch.OrchardCore.Greenhouse.Models;
+using Etch.OrchardCore.Greenhouse.Models;
 using Etch.OrchardCore.Greenhouse.Services.Dtos;
 using Flurl.Http;
 using Microsoft.Extensions.Logging;
@@ -62,7 +62,7 @@ namespace Etch.OrchardCore.Greenhouse.Services
 
             foreach (var job in board.Jobs)
             {
-                var posting = await GetJobPostingAsync(settings.BoardToken, job.PostingId);
+                var posting = await GetJobPostingAsync(settings.BoardToken, job.Id);
 
                 // assume posting is active as it appears on job board
                 posting.Active = posting.Live = true;

--- a/Services/GreenhouseApiService.cs
+++ b/Services/GreenhouseApiService.cs
@@ -2,8 +2,6 @@ using Etch.OrchardCore.Greenhouse.Models;
 using Etch.OrchardCore.Greenhouse.Services.Dtos;
 using Flurl.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using OrchardCore.Entities;
 using OrchardCore.Settings;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Services/GreenhouseApiService.cs
+++ b/Services/GreenhouseApiService.cs
@@ -2,6 +2,7 @@ using Etch.OrchardCore.Greenhouse.Models;
 using Etch.OrchardCore.Greenhouse.Services.Dtos;
 using Flurl.Http;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using OrchardCore.Entities;
 using OrchardCore.Settings;
 using System.Collections.Generic;
@@ -62,7 +63,7 @@ namespace Etch.OrchardCore.Greenhouse.Services
 
             foreach (var job in board.Jobs)
             {
-                var posting = await GetJobPostingAsync(settings.BoardToken, job.Id);
+                var posting = await GetJobPostingAsync(settings.BoardToken, job.PostingId);
 
                 // assume posting is active as it appears on job board
                 posting.Active = posting.Live = true;


### PR DESCRIPTION
Job import is failing due to Posting ID property not being properly populated. We should use the `JsonPropertyName` attribute on Job Board properties, rather than Newtonsoft.Json `JsonProperty` attribute as this no longer works with Flurl library (https://github.com/tmenier/Flurl/issues/706#issuecomment-1165507079) 