### PR TITLE
Improve handling of different metadata fields

### DIFF
--- a/Converters/StringOrArrayConverter.cs
+++ b/Converters/StringOrArrayConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Etch.OrchardCore.Greenhouse.Converters
+{
+    public class StringOrArrayConverter : JsonConverter<string[]>
+    {
+        public override string[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return [reader.GetString()];
+            }
+            else if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                List<string> values = [];
+
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (reader.TokenType == JsonTokenType.String)
+                    {
+                        values.Add(reader.GetString());
+                    }
+                }
+
+                return [.. values];
+            }
+
+            return [];
+        }
+
+        public override void Write(Utf8JsonWriter writer, string[] value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+}

--- a/Indexes/GreenhousePostingPartIndexHandler.cs
+++ b/Indexes/GreenhousePostingPartIndexHandler.cs
@@ -19,15 +19,17 @@ namespace Etch.OrchardCore.Greenhouse.Indexes
             {
                 if (metadataField.Value?.Any() ?? false)
                 {
-                    context.DocumentIndex.Set($"{nameof(GreenhousePostingPart)}.Metadata.{metadataField.Name}", metadataField.Value[0], options);
+                    context.DocumentIndex.Set($"{nameof(GreenhousePostingPart)}.Metadata.{FormatMetadataName(metadataField.Name)}", metadataField.Value[0], options);
                 }
                 else
                 {
-                    context.DocumentIndex.Set($"{nameof(GreenhousePostingPart)}.Metadata.{metadataField.Name}", "NULL", options);
+                    context.DocumentIndex.Set($"{nameof(GreenhousePostingPart)}.Metadata.{FormatMetadataName(metadataField.Name)}", "NULL", options);
                 }
             }
 
             return Task.CompletedTask;
         }
+
+        private static string FormatMetadataName(string name) => name.Replace(" ", "").Replace("-", "");
     }
 }

--- a/Services/Dtos/GreenhouseMetadata.cs
+++ b/Services/Dtos/GreenhouseMetadata.cs
@@ -1,3 +1,4 @@
+using Etch.OrchardCore.Greenhouse.Converters;
 using System.Text.Json.Serialization;
 
 namespace Etch.OrchardCore.Greenhouse.Services.Dtos
@@ -11,6 +12,7 @@ namespace Etch.OrchardCore.Greenhouse.Services.Dtos
         public string Name { get; set; }
 
         [JsonPropertyName("value")]
+        [JsonConverter(typeof(StringOrArrayConverter))]
         public string[] Value { get; set; }
 
         [JsonPropertyName("value_type")]


### PR DESCRIPTION
Within Greenhouse it's possible to have metadata fields that have a value of a single string or a collection of strings. This means the data in the API response from Greenhouse can be either a string or an array of strings. This change adds a converter to handle this scenario and converts any single string values to a collection of strings.

Additionally, this change updates the GreenhousePostingPartIndexHandler to clean up the name of the meta data field that's added to the index document.