### PR TITLE
Use Id rather than posting id

### DIFF
--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.5</Version>
+    <Version>0.4.6</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.2</Version>
+    <Version>0.4.3</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.4</Version>
+    <Version>0.4.5</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Greenhouse.csproj
+++ b/Etch.OrchardCore.Greenhouse.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
     <PackageId>Etch.OrchardCore.Greenhouse</PackageId>
     <Title>Greenhouse</Title>
     <Authors>Etch UK</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "0.4.3",
+    Version = "0.4.4",
     Website = "https://etchuk.com"
 )]
 

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "0.4.4",
+    Version = "0.4.5",
     Website = "https://etchuk.com"
 )]
 

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "0.4.5",
+    Version = "0.4.6",
     Website = "https://etchuk.com"
 )]
 

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Integrates Greenhouse with Orchard Core.",
     Name = "Greenhouse",
-    Version = "0.4.1",
+    Version = "0.4.3",
     Website = "https://etchuk.com"
 )]
 

--- a/Services/Dtos/GreenhouseJobPosting.cs
+++ b/Services/Dtos/GreenhouseJobPosting.cs
@@ -30,7 +30,7 @@ namespace Etch.OrchardCore.Greenhouse.Services.Dtos
         [JsonProperty("internal_content")]
         public string InternalContent { get; set; }
 
-        [JsonProperty("job_id")]
+        [JsonProperty("internal_job_id")]
         public long JobId { get; set; }
 
         [JsonProperty("live")]

--- a/Services/GreenhouseApiService.cs
+++ b/Services/GreenhouseApiService.cs
@@ -82,7 +82,7 @@ namespace Etch.OrchardCore.Greenhouse.Services
 
             foreach (var job in board.Jobs)
             {
-                var posting = await GetJobPostingAsync(token, job.PostingId);
+                var posting = await GetJobPostingAsync(token, job.Id);
 
                 // assume posting is active as it appears on job board
                 posting.Active = posting.Live = true;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,9 +33,8 @@ stages:
               projectName: "Etch.OrchardCore.Greenhouse"
 
           - task: UseNode@1
-            displayName: "Use Node.js 14.x"
             inputs:
-            version: '14.x'
+              version: '14.x'
 
           - task: tmarkovski.projectversionasvariable.versionintovariable.projectversionasvariable@1
             displayName: "Get Project Version as variables from Etch.OrchardCore.Greenhouse.csproj"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
       - "*"
   branches:
     include:
-      - main
+      - main, fix
 
 variables:
   buildConfiguration: "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,11 @@ stages:
               projectKey: "Etch.OrchardCore.Greenhouse"
               projectName: "Etch.OrchardCore.Greenhouse"
 
+          - task: UseNode@1
+            displayName: "Use Node.js 14.x"
+            inputs:
+            version: '14.x'
+
           - task: tmarkovski.projectversionasvariable.versionintovariable.projectversionasvariable@1
             displayName: "Get Project Version as variables from Etch.OrchardCore.Greenhouse.csproj"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,8 @@ trigger:
       - "*"
   branches:
     include:
-      - main, fix
+      - main
+      - fix
 
 variables:
   buildConfiguration: "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
   branches:
     include:
       - main
-      - fix
+      - fix/*
 
 variables:
   buildConfiguration: "Release"


### PR DESCRIPTION
Currently there's an issue in v0.4 of our Greenhouse package where the `PostingId` property on `GreenhouseJobBoardJob` objects has a query string appended to it, which is causing the `GetJobPostingAsync()` method to throw an error: `{"The input string '6212469?gh_jid=6212469' was not in a correct format."}` (where `6212469` is the job ID). I assume this is happening now because of a change in the Greenhouse API. As we can't upgrade to the latest version of our Greenhouse package on older projects, I've created a hotfix branch from v0.4.1 and have added the fix there.